### PR TITLE
Intrinsics mod

### DIFF
--- a/noobhack/game/brain.py
+++ b/noobhack/game/brain.py
@@ -55,10 +55,10 @@ class Brain:
 
     def _dispatch_intrinsic_events(self, data):
         for name, messages in intrinsics.messages.iteritems():
-            for message in messages:
+            for message, value in messages.iteritems():
                 match = re.search(message, data, re.I | re.M)
                 if match is not None:
-                    dispatcher.dispatch("intrinsic", name)
+                    dispatcher.dispatch("intrinsic", name, value)
 
     def _dispatch_status_events(self, data):
         """

--- a/noobhack/game/brain.py
+++ b/noobhack/game/brain.py
@@ -6,7 +6,7 @@ consuming and processing those events in an intelligent way.
 import re
 
 from noobhack.game.graphics import ibm
-from noobhack.game import shops, status, resistances, sounds, dungeon
+from noobhack.game import shops, status, intrinsics, sounds, dungeon
 from noobhack.game.events import dispatcher
 
 class Brain:
@@ -53,12 +53,12 @@ class Brain:
                 if match is not None:
                     dispatcher.dispatch("level-feature", feature)
 
-    def _dispatch_resistance_events(self, data):
-        for name, messages in resistances.messages.iteritems():
+    def _dispatch_intrinsic_events(self, data):
+        for name, messages in intrinsics.messages.iteritems():
             for message in messages:
                 match = re.search(message, data, re.I | re.M)
                 if match is not None:
-                    dispatcher.dispatch("resistance", name)
+                    dispatcher.dispatch("intrinsic", name)
 
     def _dispatch_status_events(self, data):
         """
@@ -218,7 +218,7 @@ class Brain:
         self.about_to_branchport = False
 
         self._dispatch_status_events(data)
-        self._dispatch_resistance_events(data)
+        self._dispatch_intrinsic_events(data)
         self._dispatch_turn_change_event()
         self._dispatch_trap_door_event(data)
         self._dispatch_level_change_event()

--- a/noobhack/game/intrinsics.py
+++ b/noobhack/game/intrinsics.py
@@ -1,65 +1,81 @@
-# TODO: Look up other resistances 
 messages = {
-    "warning": set((
-        "You feel sensitive!"
-      )),
-    "shock resistance": set((
-        "Your health currently feels amplified!",
-        "You feel insulated!",
-        "You are shock resistant",
-        "You feel grounded in reality."
-    )),
-    "fire resistance": set((
-        "You be chillin'.",
-        "You are fire resistant",
-        "You feel a momentary chill."
-    )),
-    "cold resistance": set((
-        "You are cold resistant",
-        "You feel warm!",
-        "You feel full of hot air."
-    )),
-    "disintegration resistance": set((
-        "You are disintegration-resistant",
-        "You feel very firm.",
-        "You feel totally together, man."
-    )),
-    "poison resistance": set((
-        "You are poison resistant",
-        "You feel( especially)? (healthy)|(hardy)"
-    )),
-    "sleep resistance": set((
-        "You are sleep resistant",
-        "You feel( wide)? awake"
-    )),
-    "Aggravate monster": set((
-        "You feel that monsters are aware of your presence"
-    )),
-    "Invisible": set((
-        "You feel hidden!"
-    )),
-    "See invisible": set((
-        "You see an image of someone stalking you.",
-        "You feel transparent",
-        "You feel very self-conscious", 
-        "Your vision becomes clear"
-    )),
-    "Searching": set((
-        "You feel perceptive!"
-    )),
-    "Speed": set((
-        "You feel quick!"
-    )),
-  "Teleportitis": set((
-     "You feel very jumpy",
-  "You feel diffuse"
-  )),
-  "Teleport control": set((
-  "You feel in control of yourself",
-  "You feel centered in your personal space"
-  )),
-  "Telepathy": set((
-  "You feel in touch with the cosmos",
-  "You feel a strange mental acuity"
-  ))
+    "Warning": {
+        "You feel sensitive!":True,
+        "You feel less sensitive!":False,
+     },
+    "Shock resistance": {
+        "Your health currently feels amplified!":True,
+        "You feel insulated!":True,
+        "You are shock resistant":True,
+        "You feel grounded in reality.":True,
+        "You feel conductive":False
+    },
+    "Fire resistance": {
+        "You be chillin'.":True,
+        "You feel cool!":True,
+        "You are fire resistant":True,
+        "You feel a momentary chill.":True,
+        "You feel warmer!":False
+    },
+    "Cold resistance": {
+        "You are cold resistant":True,
+        "You feel warm!":True,
+        "You feel full of hot air.":True,
+        "You feel cooler!":False
+    },
+    "Disintegration resist.": {
+        "You are disintegration-resistant":True,
+        "You feel very firm.":True,
+        "You feel totally together, man.":True        
+    },
+    "Poison resistance": {
+        "You are poison resistant":True,
+        "You feel( especially)? (healthy)|(hardy)":True,
+        "You feel a little sick!":False
+    },
+    "Sleep resistance": {
+        "You are sleep resistant":True,
+        "You feel( wide)? awake":True,
+        "You feel tired!":False
+    },
+    "Aggravate monster": {
+        "You feel that monsters are aware of your presence":True,
+        "You feel less attractive":False
+    },
+    "Protection": {
+        "You feel vulnerable":False
+    },
+    "Invisible": {
+        "You feel hidden!":True
+    },
+    "See invisible": {
+        "You see an image of someone stalking you.":True,
+        "You feel transparent":True,
+        "You feel very self-conscious":True, 
+        "Your vision becomes clear":True
+    },
+    "Searching": {
+        "You feel perceptive!":True
+    },
+    "Speed": {
+        "You feel quick!":True,
+        "You feel yourself speed up.":True, # speed boots put on (want this here?)!
+        "You feel yourself slow down.":False, # speed boots removed (want this here?)!
+        "You feel slow!":False
+    },
+    "Teleportitis": {
+       "You feel very jumpy":True,
+       "You feel diffuse":True,
+       "You feel less jumpy":False
+    },
+    "Teleport control": {
+        "You feel in control of yourself":True,
+        "You feel controlled!":True,
+        "You feel centered in your personal space":True,
+       "You feel less jumpy":False
+    },
+    "Telepathy": {
+        "You feel in touch with the cosmos":True,
+        "You feel a strange mental acuity":True
+    }
 }

--- a/noobhack/game/intrinsics.py
+++ b/noobhack/game/intrinsics.py
@@ -1,7 +1,7 @@
 # TODO: Look up other resistances 
 messages = {
     "warning": set((
-      "You feel sensitive!"
+        "You feel sensitive!"
       )),
     "shock resistance": set((
         "Your health currently feels amplified!",
@@ -32,4 +32,34 @@ messages = {
         "You are sleep resistant",
         "You feel( wide)? awake"
     )),
+    "Aggravate monster": set((
+        "You feel that monsters are aware of your presence"
+    )),
+    "Invisible": set((
+        "You feel hidden!"
+    )),
+    "See invisible": set((
+        "You see an image of someone stalking you.",
+        "You feel transparent",
+        "You feel very self-conscious", 
+        "Your vision becomes clear"
+    )),
+    "Searching": set((
+        "You feel perceptive!"
+    )),
+    "Speed": set((
+        "You feel quick!"
+    )),
+  "Teleportitis": set((
+     "You feel very jumpy",
+  "You feel diffuse"
+  )),
+  "Teleport control": set((
+  "You feel in control of yourself",
+  "You feel centered in your personal space"
+  )),
+  "Telepathy": set((
+  "You feel in touch with the cosmos",
+  "You feel a strange mental acuity"
+  ))
 }

--- a/noobhack/game/player.py
+++ b/noobhack/game/player.py
@@ -15,8 +15,11 @@ class Player:
         events.dispatcher.add_event_listener("status", self._status_handler)
         events.dispatcher.add_event_listener("intrinsic", self._intrinsic_handler)
 
-    def _intrinsic_handler(self, event, name):
-        self.intrinsics.add(name)
+    def _intrinsic_handler(self, event, name, value):
+        if name in self.intrinsics and value == False:
+            self.intrinsics.remove(name)
+        elif name not in self.intrinsics and value == True:
+            self.intrinsics.add(name)
 
     def _status_handler(self, event, name, value):
         if name in self.status and value == False:

--- a/noobhack/game/player.py
+++ b/noobhack/game/player.py
@@ -9,14 +9,14 @@ class Player:
 
     def __init__(self):
         self.status = set() 
-        self.resistances = set()
+        self.intrinsics = set()
 
     def listen(self):
         events.dispatcher.add_event_listener("status", self._status_handler)
-        events.dispatcher.add_event_listener("resistance", self._resistance_handler)
+        events.dispatcher.add_event_listener("intrinsic", self._intrinsic_handler)
 
-    def _resistance_handler(self, event, name):
-        self.resistances.add(name)
+    def _intrinsic_handler(self, event, name):
+        self.intrinsics.add(name)
 
     def _status_handler(self, event, name, value):
         if name in self.status and value == False:

--- a/noobhack/game/resistances.py
+++ b/noobhack/game/resistances.py
@@ -1,31 +1,34 @@
 # TODO: Look up other resistances 
 messages = {
-    "shock": set((
+    "warning": set((
+      "You feel sensitive!"
+      )),
+    "shock resistance": set((
         "Your health currently feels amplified!",
         "You feel insulated!",
         "You are shock resistant",
         "You feel grounded in reality."
     )),
-    "fire": set((
+    "fire resistance": set((
         "You be chillin'.",
         "You are fire resistant",
         "You feel a momentary chill."
     )),
-    "cold": set((
+    "cold resistance": set((
         "You are cold resistant",
         "You feel warm!",
         "You feel full of hot air."
     )),
-    "disintegration": set((
+    "disintegration resistance": set((
         "You are disintegration-resistant",
         "You feel very firm.",
         "You feel totally together, man."
     )),
-    "poison": set((
+    "poison resistance": set((
         "You are poison resistant",
         "You feel( especially)? (healthy)|(hardy)"
     )),
-    "sleep": set((
+    "sleep resistance": set((
         "You are sleep resistant",
         "You feel( wide)? awake"
     )),

--- a/noobhack/ui.py
+++ b/noobhack/ui.py
@@ -9,7 +9,7 @@ import sys
 import fcntl
 import curses 
 import struct
-mport locale
+import locale
 import termios
 
 from noobhack.game import status, shops
@@ -319,7 +319,7 @@ class Helper:
     `redraw` is called.
     """
 
-    intrinsic_width = 12
+    intrinsic_width = 25
     status_width = 12
     level_width = 25 
 

--- a/noobhack/ui.py
+++ b/noobhack/ui.py
@@ -9,7 +9,7 @@ import sys
 import fcntl
 import curses 
 import struct
-import locale
+mport locale
 import termios
 
 from noobhack.game import status, shops
@@ -319,7 +319,7 @@ class Helper:
     `redraw` is called.
     """
 
-    resistance_width = 12
+    intrinsic_width = 12
     status_width = 12
     level_width = 25 
 
@@ -354,7 +354,7 @@ class Helper:
         return 1 + max(1, max(
             len(level.features) + len(level.shops),
             len(self._get_statuses()),
-            len(self.player.resistances),
+            len(self.player.intrinsics),
         ))
 
     def _top(self):
@@ -410,15 +410,15 @@ class Helper:
 
         return dungeon_frame
 
-    def _resistance_box(self):
+    def _intrinsic_box(self):
         """
-        Create the pane with information with the player's current resistances.
+        Create the pane with information with the player's current intrinsics.
         """
 
         default = "(none)"
 
         def res_color(res):
-            """Return the color of a resistance."""
+            """Return the color of a intrinsic."""
             if res == "fire": 
                 return curses.COLOR_RED
             elif res == "cold": 
@@ -432,23 +432,23 @@ class Helper:
 
         res_frame = curses.newwin(
             self._height(), 
-            self.resistance_width, 
+            self.intrinsic_width, 
             self._top(), 
             self.level_width + self.status_width - 2
         )
 
         res_frame.erase()
         res_frame.border("|", "|", "-", " ", "+", "+", "|", "|")
-        res_frame.addstr(0, 2, " resist ")
-        res_frame.chgat(0, 2, len(" resist "), get_color(curses.COLOR_CYAN))
-        resistances = sorted(self.player.resistances)
-        for row, res in enumerate(resistances, 1):
+        res_frame.addstr(0, 2, " intrinsic ")
+        res_frame.chgat(0, 2, len(" intrinsic "), get_color(curses.COLOR_CYAN))
+        intrinsics = sorted(self.player.intrinsics)
+        for row, res in enumerate(intrinsics, 1):
             color = get_color(res_color(res))
-            res_frame.addnstr(row, 1, res, self.resistance_width-2)
-            res_frame.chgat(row, 1, min(len(res), self.resistance_width-2), color)
+            res_frame.addnstr(row, 1, res, self.intrinsic_width-2)
+            res_frame.chgat(row, 1, min(len(res), self.intrinsic_width-2), color)
 
-        if len(resistances) == 0:
-            center = (self.resistance_width / 2) - (len(default) / 2)
+        if len(intrinsics) == 0:
+            center = (self.intrinsic_width / 2) - (len(default) / 2)
             res_frame.addstr(1, center, default)
 
         return res_frame
@@ -583,11 +583,11 @@ class Helper:
 
         status_frame = self._status_box()
         dungeon_frame = self._level_box()
-        resist_frame = self._resistance_box()
+        intrinsic_frame = self._intrinsic_box()
 
         status_frame.overwrite(window)
         dungeon_frame.overwrite(window)
-        resist_frame.overwrite(window)
+        intrinsic_frame.overwrite(window)
 
         window.noutrefresh()
 


### PR DESCRIPTION
Hi Sam,

Don't know whether you'll like these changes but I thought they might be interesting to you. 

So, inspired by your "TODO" message, I've filled out the Resistances.py with many of the intrinsics. As a result it makes less sense to call these "resistances", so the resistance class and file etc. are renamed to "intrinsics" throughout.  I now use the same method as in your status.py to catch and display when intrinsics are lost.

Problems with this; speed intrinsic is now shown in two places - (as is teleportitis, I think) - and it'll now show as an intrinsic when you put on or remove boots. This might be a little inconsistent as most of the other intrinsics are gained by eating something or gaining levels.  On the other hand, what's the difference...? 

 You might want to abbreviate the intrinsic names as they take up quite a bit of screen real-estate when you've got a lot (a level 30 monk, for example).

Of course you can test this easily by using Wizard mode with a monk, wishing for about 30 gain-level potions and swigging them while you watch the tab-screen.  I've not tested the changes _heavily_ but they should be fairly straightforward to understand and I can't see how they'd break anything else.

Chris
