### PR TITLE
Intrinsics mod

### DIFF
--- a/intrinsics.cpp
+++ b/intrinsics.cpp
@@ -1,0 +1,131 @@
+#include <fstream>
+#include <string>
+#include <map>
+
+#include <Python.h>
+
+using namespace std;
+
+namespace
+{
+    static bool firstTime = true;
+
+    struct Effect
+    {
+        string intrinsicName_;
+        bool result_; // enabled or disabled
+    };
+
+    static map<string, Effect> effects;
+
+    static void ParseDictionary(PyObject* intrinsicsDictionary, wofstream& fs)
+    {
+
+        PyObject *keys = PyDict_Keys(intrinsicsDictionary);
+        for(int i = 0; i < PyList_Size(keys); ++i)
+        {
+            PyObject *thisKey = PyList_GetItem(keys, i);
+            PyObject *thisValue = PyDict_GetItem(intrinsicsDictionary, thisKey); 
+            if(PyDict_Check(thisValue))
+            {
+                const string keyString = PyString_AsString(thisKey); 
+                const wstring wsKeyString(keyString.begin(), keyString.end());
+
+                PyObject *subKeys = PyDict_Keys(thisValue);
+
+                for(int j = 0; j < PyList_Size(subKeys); ++j)
+                {
+                    PyObject *thisSubKey = PyList_GetItem(subKeys, j);
+
+                    const string subKeyString = PyString_AsString(thisSubKey); 
+                    const wstring wsSubKeyString(subKeyString.begin(), subKeyString.end());
+
+
+                    PyObject *thisSubValue = PyDict_GetItem(thisValue, thisSubKey);
+                    if(thisSubValue)
+                    {
+                        if(PyBool_Check(thisSubValue))
+                        {
+
+                            fs << L"Search Text: " << wsSubKeyString;
+                            fs << L" value: " << (thisSubValue == Py_True ? L"enable" : L"disable");
+                            fs << L" " << wsKeyString << endl;
+                        }
+                    }
+                    else
+                    {
+                        fs << L"value for " << wsSubKeyString << L" wasn't found" << endl;
+                    }
+                }
+            }
+        }
+    }
+}
+
+static PyObject* DispatchIntrinsics(PyObject *self, PyObject* args)
+{    
+    wofstream fs("out.txt", ios::app);
+    fs << L"In DispatchIntrinsics\n";
+
+    if(PyTuple_Size(args) != 2)
+    {
+        fs << L"Two args expected (found " << PyTuple_Size(args) << L")!\n";
+        return PyDict_New();
+    }
+
+    if(firstTime)
+    {
+        fs << L"First time! Collating data!" << endl;
+
+        PyObject *intrinsicsDictionary = PyTuple_GetItem(args, 0);
+        if(PyDict_Check(intrinsicsDictionary))
+        {
+            ParseDictionary(intrinsicsDictionary, fs);
+        }
+        else
+        {
+            fs << L" Intrinsics dictionary isn't a dictionary; we're buggered\n";
+            return NULL;
+        }
+    }
+
+    PyObject *messageData = PyTuple_GetItem(args, 1);
+    if(PyList_Check(messageData))
+    {
+        fs << L"message data is a list (now expected...)\n";
+        int listSize = PyList_Size(messageData);
+        fs << L"Size of list: " << listSize << endl;
+        for(int i=0;i<listSize;++i) 
+        {
+            PyObject* line = PyList_GetItem(messageData, i);
+
+            if(PyUnicode_Check(line))
+            {
+                const wstring wsLine(reinterpret_cast<wchar_t*>(PyUnicode_AS_UNICODE(line)));
+                fs << L"line (isUnicode) " << i << L" = " << wsLine << endl;
+            }
+        }
+    }
+
+    bool added = true;
+    PyObject* results = PyDict_New();
+    PyObject* trueFalse = added ? Py_True : Py_False;
+    int res = PyDict_SetItem(results, PyString_FromString("Keyvalue"), trueFalse);
+    if(res != 0)
+    {
+        fs << L"pydict_setitem failed!\n";
+    }
+    return results;
+}           
+
+static PyMethodDef IntrinsicsMethods[] = 
+{
+    {"DispatchIntrinsics", DispatchIntrinsics, METH_VARARGS, "Figure out Intrinsics changed..."},
+    {NULL, NULL, 0, NULL}
+};
+
+PyMODINIT_FUNC initintrinsicsC()
+{
+    (void) Py_InitModule("intrinsicsC", IntrinsicsMethods);
+}
+

--- a/intrinsics.cpp
+++ b/intrinsics.cpp
@@ -1,6 +1,7 @@
 #include <fstream>
 #include <string>
 #include <map>
+#include <vector>
 
 #include <Python.h>
 
@@ -12,53 +13,61 @@ namespace
 
     struct Effect
     {
-        string intrinsicName_;
-        bool result_; // enabled or disabled
+	Effect()
+	{}
+
+	Effect(const string& name, bool result) : intrinsicName_(name), result_(result)
+	{}
+
+	string intrinsicName_;
+	bool result_; // enabled or disabled
     };
 
-    static map<string, Effect> effects;
+    typedef map<wstring, Effect> EffectsMap;
+    static EffectsMap effects;
 
     static void ParseDictionary(PyObject* intrinsicsDictionary, wofstream& fs)
     {
+	PyObject *keys = PyDict_Keys(intrinsicsDictionary);
+	for(int i = 0; i < PyList_Size(keys); ++i)
+	{
+	    PyObject *thisKey = PyList_GetItem(keys, i);
+	    PyObject *thisValue = PyDict_GetItem(intrinsicsDictionary, thisKey); 
+	    if(PyDict_Check(thisValue))
+	    {
+		const string keyString = PyString_AsString(thisKey); 
+		const wstring wsKeyString(keyString.begin(), keyString.end());
 
-        PyObject *keys = PyDict_Keys(intrinsicsDictionary);
-        for(int i = 0; i < PyList_Size(keys); ++i)
-        {
-            PyObject *thisKey = PyList_GetItem(keys, i);
-            PyObject *thisValue = PyDict_GetItem(intrinsicsDictionary, thisKey); 
-            if(PyDict_Check(thisValue))
-            {
-                const string keyString = PyString_AsString(thisKey); 
-                const wstring wsKeyString(keyString.begin(), keyString.end());
+		PyObject *subKeys = PyDict_Keys(thisValue);
 
-                PyObject *subKeys = PyDict_Keys(thisValue);
+		for(int j = 0; j < PyList_Size(subKeys); ++j)
+		{
+		    PyObject *thisSubKey = PyList_GetItem(subKeys, j);
 
-                for(int j = 0; j < PyList_Size(subKeys); ++j)
-                {
-                    PyObject *thisSubKey = PyList_GetItem(subKeys, j);
-
-                    const string subKeyString = PyString_AsString(thisSubKey); 
-                    const wstring wsSubKeyString(subKeyString.begin(), subKeyString.end());
+		    const string subKeyString = PyString_AsString(thisSubKey); 
+		    const wstring wsSubKeyString(subKeyString.begin(), subKeyString.end());
 
 
-                    PyObject *thisSubValue = PyDict_GetItem(thisValue, thisSubKey);
-                    if(thisSubValue)
-                    {
-                        if(PyBool_Check(thisSubValue))
-                        {
+		    PyObject *thisSubValue = PyDict_GetItem(thisValue, thisSubKey);
+		    if(thisSubValue)
+		    {
+			if(PyBool_Check(thisSubValue))
+			{
 
-                            fs << L"Search Text: " << wsSubKeyString;
-                            fs << L" value: " << (thisSubValue == Py_True ? L"enable" : L"disable");
-                            fs << L" " << wsKeyString << endl;
-                        }
-                    }
-                    else
-                    {
-                        fs << L"value for " << wsSubKeyString << L" wasn't found" << endl;
-                    }
-                }
-            }
-        }
+			    fs << L"Search Text: " << wsSubKeyString;
+			    fs << L" value: " << (thisSubValue == Py_True ? L"enable" : L"disable");
+			    fs << L" " << wsKeyString << endl;
+
+			    effects[wsSubKeyString] = Effect(keyString, thisSubValue == Py_True);
+			}
+		    }
+		    else
+		    {
+			fs << L"value for " << wsSubKeyString << L" wasn't found" << endl;
+		    }
+		}
+	    }
+	}
     }
 }
 
@@ -69,54 +78,94 @@ static PyObject* DispatchIntrinsics(PyObject *self, PyObject* args)
 
     if(PyTuple_Size(args) != 2)
     {
-        fs << L"Two args expected (found " << PyTuple_Size(args) << L")!\n";
-        return PyDict_New();
+	fs << L"Two args expected (found " << PyTuple_Size(args) << L")!\n";
+	return PyDict_New();
     }
 
     if(firstTime)
     {
-        fs << L"First time! Collating data!" << endl;
+	fs << L"First time! Collating data!" << endl;
 
-        PyObject *intrinsicsDictionary = PyTuple_GetItem(args, 0);
-        if(PyDict_Check(intrinsicsDictionary))
-        {
-            ParseDictionary(intrinsicsDictionary, fs);
-        }
-        else
-        {
-            fs << L" Intrinsics dictionary isn't a dictionary; we're buggered\n";
-            return NULL;
-        }
+	PyObject *intrinsicsDictionary = PyTuple_GetItem(args, 0);
+	if(PyDict_Check(intrinsicsDictionary))
+	{
+	    ParseDictionary(intrinsicsDictionary, fs);
+	}
+	else
+	{
+	    fs << L" Intrinsics dictionary isn't a dictionary; we're buggered\n";
+	    return NULL;
+	}
     }
+
+    vector<string> added;
+    vector<string> removed;
 
     PyObject *messageData = PyTuple_GetItem(args, 1);
     if(PyList_Check(messageData))
     {
-        fs << L"message data is a list (now expected...)\n";
-        int listSize = PyList_Size(messageData);
-        fs << L"Size of list: " << listSize << endl;
-        for(int i=0;i<listSize;++i) 
-        {
-            PyObject* line = PyList_GetItem(messageData, i);
+	int listSize = PyList_Size(messageData);
 
-            if(PyUnicode_Check(line))
-            {
-                const wstring wsLine(reinterpret_cast<wchar_t*>(PyUnicode_AS_UNICODE(line)));
-                fs << L"line (isUnicode) " << i << L" = " << wsLine << endl;
-            }
-        }
+	fs << L"Number of rows: " << listSize << endl;
+
+	for(int i=0;i<listSize;++i) 
+	{
+	    PyObject* line = PyList_GetItem(messageData, i);
+
+	    if(PyUnicode_Check(line))
+	    {
+		const wstring wsLine(reinterpret_cast<wchar_t*>(PyUnicode_AS_UNICODE(line)));
+		fs << L"line (unicode) " << i << L" = " << wsLine << endl;
+
+		for(EffectsMap::const_iterator it = effects.begin();
+			it != effects.end();
+			++it)
+		{    
+		    const wstring& searchterm = (*it).first;
+
+		    fs << L"testing for " << searchterm << endl;
+		    if(string::npos != wsLine.find(searchterm))
+		    {			
+			if(it->second.result_)
+			{
+			    fs << L"found an Enable term" 
+				<< L"for " <<  wstring(it->second.intrinsicName_.begin(), it->second.intrinsicName_.end())
+				<< endl;					 
+			    added.push_back(it->second.intrinsicName_);
+			}			 
+			else
+			{ 
+			    fs << L"found a Disable term" 
+				<< L"for " <<  wstring(it->second.intrinsicName_.begin(), it->second.intrinsicName_.end())
+				<< endl;		
+			    removed.push_back(it->second.intrinsicName_);
+			}
+		    }			    
+		}
+	    }
+	}
     }
 
-    bool added = true;
     PyObject* results = PyDict_New();
-    PyObject* trueFalse = added ? Py_True : Py_False;
-    int res = PyDict_SetItem(results, PyString_FromString("Keyvalue"), trueFalse);
-    if(res != 0)
-    {
-        fs << L"pydict_setitem failed!\n";
+    for(vector<string>::const_iterator it = added.begin(); it != added.end(); ++it)
+    {	    
+	int res = PyDict_SetItem(results, PyString_FromString(it->c_str()), Py_True);
+	if(res != 0)
+	{
+	    fs << L"pydict_setitem failed!\n";
+	}
+    }
+    for(vector<string>::const_iterator it = removed.begin(); it != removed.end(); ++it)
+    {	    
+	int res = PyDict_SetItem(results, PyString_FromString(it->c_str()), Py_False);
+	if(res != 0)
+	{
+	    fs << L"pydict_setitem failed!\n";
+	}
     }
     return results;
-}           
+}       
+
 
 static PyMethodDef IntrinsicsMethods[] = 
 {

--- a/intrinsics.cpp
+++ b/intrinsics.cpp
@@ -125,18 +125,22 @@ static PyObject* DispatchIntrinsics(PyObject *self, PyObject* args)
 
 		    fs << L"testing for " << searchterm << endl;
 		    if(string::npos != wsLine.find(searchterm))
-		    {			
+		    {	
+			const string name(it->second.intrinsicName_);
+	    		const wstring wsName(name.begin(), name.end());
+
 			if(it->second.result_)
 			{
 			    fs << L"found an Enable term" 
-				<< L"for " <<  wstring(it->second.intrinsicName_.begin(), it->second.intrinsicName_.end())
+				<< L"for " <<  wstring(wsName)
 				<< endl;					 
 			    added.push_back(it->second.intrinsicName_);
 			}			 
 			else
 			{ 
-			    fs << L"found a Disable term" 
-				<< L"for " <<  wstring(it->second.intrinsicName_.begin(), it->second.intrinsicName_.end())
+
+			    fs << L"found a Disable term for " 
+				<<  wstring(wsName)
 				<< endl;		
 			    removed.push_back(it->second.intrinsicName_);
 			}
@@ -148,7 +152,9 @@ static PyObject* DispatchIntrinsics(PyObject *self, PyObject* args)
 
     PyObject* results = PyDict_New();
     for(vector<string>::const_iterator it = added.begin(); it != added.end(); ++it)
-    {	    
+    {	   
+	const wstring wsIt(it->begin(), it->end());
+       	fs << L"adding 	Enabled for " << wsIt << endl;
 	int res = PyDict_SetItem(results, PyString_FromString(it->c_str()), Py_True);
 	if(res != 0)
 	{
@@ -157,6 +163,8 @@ static PyObject* DispatchIntrinsics(PyObject *self, PyObject* args)
     }
     for(vector<string>::const_iterator it = removed.begin(); it != removed.end(); ++it)
     {	    
+	const wstring wsIt(it->begin(), it->end());
+       	fs << L"adding Disabled for " << wsIt << endl;
 	int res = PyDict_SetItem(results, PyString_FromString(it->c_str()), Py_False);
 	if(res != 0)
 	{

--- a/noobhack/game/brain.py
+++ b/noobhack/game/brain.py
@@ -7,7 +7,6 @@ import re
 
 from noobhack import ui
 import vt102
-import logging
 
 from noobhack.game.graphics import ibm
 from noobhack.game import shops, status, intrinsics, sounds, dungeon
@@ -60,21 +59,11 @@ class Brain:
                     dispatcher.dispatch("level-feature", feature)
 
     def _dispatch_intrinsic_events(self, data):    
-
-        logging.basicConfig(filename="debug.out", level=logging.DEBUG)
-        logging.debug(ui.size())        
-        logging.debug(self.term.display)
-
         intrinsicsResult = intrinsicsC.DispatchIntrinsics(
             intrinsics.messages, self.term.display)
   
         for name, value in intrinsicsResult.items():
           dispatcher.dispatch("intrinsic", name, value)
-#        for name, messages in intrinsics.messages.iteritems():
-#            for message, value in messages.iteritems():
-#                match = re.search(message, data, re.I | re.M)
-#                if match is not None:
-#                    dispatcher.dispatch("intrinsic", name, value)
 
     def _dispatch_status_events(self, data):
         """

--- a/noobhack/game/brain.py
+++ b/noobhack/game/brain.py
@@ -5,9 +5,15 @@ consuming and processing those events in an intelligent way.
 
 import re
 
+from noobhack import ui
+import vt102
+import logging
+
 from noobhack.game.graphics import ibm
 from noobhack.game import shops, status, intrinsics, sounds, dungeon
 from noobhack.game.events import dispatcher
+
+import intrinsicsC
 
 class Brain:
     """
@@ -53,12 +59,22 @@ class Brain:
                 if match is not None:
                     dispatcher.dispatch("level-feature", feature)
 
-    def _dispatch_intrinsic_events(self, data):
-        for name, messages in intrinsics.messages.iteritems():
-            for message, value in messages.iteritems():
-                match = re.search(message, data, re.I | re.M)
-                if match is not None:
-                    dispatcher.dispatch("intrinsic", name, value)
+    def _dispatch_intrinsic_events(self, data):    
+
+        logging.basicConfig(filename="debug.out", level=logging.DEBUG)
+        logging.debug(ui.size())        
+        logging.debug(self.term.display)
+
+        intrinsicsResult = intrinsicsC.DispatchIntrinsics(
+            intrinsics.messages, self.term.display)
+  
+        for name, value in intrinsicsResult.items():
+          dispatcher.dispatch("intrinsic", name, value)
+#        for name, messages in intrinsics.messages.iteritems():
+#            for message, value in messages.iteritems():
+#                match = re.search(message, data, re.I | re.M)
+#                if match is not None:
+#                    dispatcher.dispatch("intrinsic", name, value)
 
     def _dispatch_status_events(self, data):
         """

--- a/noobhack/game/cpp/intrinsics.cpp
+++ b/noobhack/game/cpp/intrinsics.cpp
@@ -1,5 +1,7 @@
 #include <Python.h>
 
+#include <boost/regex.hpp>
+
 #include <string>
 #include <sstream>
 #include <vector>
@@ -48,7 +50,7 @@ namespace
 	return Py_True == pyOb;
     }
 
-    static void ParseDictionary(PyObject* dictionary)
+static void ParseDictionary(PyObject* dictionary)
     {
 	firstTime = false; // we don't want to do this again...
 	
@@ -89,6 +91,7 @@ static PyObject* DispatchIntrinsics(PyObject *self, PyObject* args)
     if(firstTime)
     {
 	PyObject *dictionary = PyTuple_GetItem(args, 0);
+	// is type-check needed?
 	if(PyDict_Check(dictionary))
 	{
 	    ParseDictionary(dictionary);
@@ -104,6 +107,7 @@ static PyObject* DispatchIntrinsics(PyObject *self, PyObject* args)
     StdResults stdResults;
 
     PyObject *messageData = PyTuple_GetItem(args, 1);
+    // is type-check needed?
     if(PyList_Check(messageData))
     {
 	int listSize = PyList_Size(messageData);
@@ -133,7 +137,7 @@ static PyObject* DispatchIntrinsics(PyObject *self, PyObject* args)
 			it != searchItems.end();
 			++it)
 	{    
-		if(string::npos != fullScreenData.find(it->searchTerm_))
+		if(boost::regex_search(fullScreenData, boost::wregex(it->searchTerm_)))
 		{	
 			const string name(it->name_);
 			const wstring wsName(name.begin(), name.end());

--- a/noobhack/game/cpp/intrinsics.cpp
+++ b/noobhack/game/cpp/intrinsics.cpp
@@ -1,6 +1,7 @@
 #include <Python.h>
 
 #include <string>
+#include <sstream>
 #include <vector>
 
 using namespace std;
@@ -107,6 +108,8 @@ static PyObject* DispatchIntrinsics(PyObject *self, PyObject* args)
     {
 	int listSize = PyList_Size(messageData);
 
+	wostringstream lines;
+
 	for(int i=0 ; i < listSize ; ++i) 
 	{
 	    PyObject* line = PyList_GetItem(messageData, i);
@@ -116,39 +119,43 @@ static PyObject* DispatchIntrinsics(PyObject *self, PyObject* args)
 	    }
 
 	    const wstring wsLine( reinterpret_cast< wchar_t* >( PyUnicode_AS_UNICODE(line) ) );
-	
+	    lines << wsLine;
+
 	    if(wsLine == L"")
 	    {
 		continue;
 	    }
-
-	    for(TextSearchItems::const_iterator it = searchItems.begin();
-		    it != searchItems.end();
-		    ++it)
-	    {    
-		if(string::npos != wsLine.find(it->searchTerm_))
-		{	
-		    const string name(it->name_);
-		    const wstring wsName(name.begin(), name.end());
-
-		    if(it->result_)
-		    {
-			stdResults.push_back( StdResult(it->name_, true) );
-		    }			 
-		    else
-		    { 
-			stdResults.push_back( StdResult(it->name_, false) );
-		    }
-		}			    
-	    }
 	}
+
+	const wstring fullScreenData = lines.str();
+
+	for(TextSearchItems::const_iterator it = searchItems.begin();
+			it != searchItems.end();
+			++it)
+	{    
+		if(string::npos != fullScreenData.find(it->searchTerm_))
+		{	
+			const string name(it->name_);
+			const wstring wsName(name.begin(), name.end());
+
+			if(it->result_)
+			{
+				stdResults.push_back( StdResult(it->name_, true) );
+			}			 
+			else
+			{ 
+				stdResults.push_back( StdResult(it->name_, false) );
+			}
+		}			    
+	}
+
     }
 
     PyObject* pyResults = PyDict_New();
     for(StdResults::const_iterator it = stdResults.begin(); it != stdResults.end(); ++it)
     {	   
-	const string name(it->first);
-        PyDict_SetItem(pyResults, PyString_FromString(name.c_str()), it->second ? Py_True : Py_False);
+	    const string name(it->first);
+	    PyDict_SetItem(pyResults, PyString_FromString(name.c_str()), it->second ? Py_True : Py_False);
     }
     return pyResults;
 }       
@@ -156,12 +163,12 @@ static PyObject* DispatchIntrinsics(PyObject *self, PyObject* args)
 
 static PyMethodDef IntrinsicsMethods[] = 
 {
-    {"DispatchIntrinsics", DispatchIntrinsics, METH_VARARGS, "Figure out Intrinsics changed..."},
-    {NULL, NULL, 0, NULL}
+	{"DispatchIntrinsics", DispatchIntrinsics, METH_VARARGS, "Figure out Intrinsics changed..."},
+	{NULL, NULL, 0, NULL}
 };
 
 PyMODINIT_FUNC initintrinsicsC()
 {
-    (void) Py_InitModule("intrinsicsC", IntrinsicsMethods);
+	(void) Py_InitModule("intrinsicsC", IntrinsicsMethods);
 }
 

--- a/noobhack/game/intrinsics.py
+++ b/noobhack/game/intrinsics.py
@@ -1,42 +1,42 @@
 messages = {
     "Warning": {
-        "You feel sensitive!":True,
-        "You feel less sensitive!":False,
+        "You feel sensitive":True,
+        "You feel less sensitive":False,
      },
     "Shock resistance": {
-        "Your health currently feels amplified!":True,
-        "You feel insulated!":True,
+        "Your health currently feels amplified":True,
+        "You feel insulated":True,
         "You are shock resistant":True,
-        "You feel grounded in reality.":True,
+        "You feel grounded in reality":True,
         "You feel conductive":False
     },
     "Fire resistance": {
-        "You be chillin'.":True,
-        "You feel cool!":True,
+        "You be chillin'":True,
+        "You feel cool":True,
         "You are fire resistant":True,
-        "You feel a momentary chill.":True,
-        "You feel warmer!":False
+        "You feel a momentary chill":True,
+        "You feel warmer":False
     },
     "Cold resistance": {
         "You are cold resistant":True,
-        "You feel warm!":True,
-        "You feel full of hot air.":True,
-        "You feel cooler!":False
+        "You feel warm":True,
+        "You feel full of hot air":True,
+        "You feel cooler":False
     },
-    "Disintegration resist.": {
+    "Disintegration resist": {
         "You are disintegration-resistant":True,
-        "You feel very firm.":True,
-        "You feel totally together, man.":True        
+        "You feel very firm":True,
+        "You feel totally together, man":True        
     },
     "Poison resistance": {
         "You are poison resistant":True,
         "You feel( especially)? (healthy)|(hardy)":True,
-        "You feel a little sick!":False
+        "You feel a little sick":False
     },
     "Sleep resistance": {
         "You are sleep resistant":True,
         "You feel( wide)? awake":True,
-        "You feel tired!":False
+        "You feel tired":False
     },
     "Aggravate monster": {
         "You feel that monsters are aware of your presence":True,
@@ -46,22 +46,22 @@ messages = {
         "You feel vulnerable":False
     },
     "Invisible": {
-        "You feel hidden!":True
+        "You feel hidden":True
     },
     "See invisible": {
-        "You see an image of someone stalking you.":True,
+        "You see an image of someone stalking you":True,
         "You feel transparent":True,
         "You feel very self-conscious":True, 
         "Your vision becomes clear":True
     },
     "Searching": {
-        "You feel perceptive!":True
+        "You feel perceptive":True
     },
     "Speed": {
-        "You feel quick!":True,
-        "You feel yourself speed up.":True, # speed boots put on (want this here?)!
-        "You feel yourself slow down.":False, # speed boots removed (want this here?)!
-        "You feel slow!":False
+        "You feel quick":True,
+        "You feel yourself speed up":True, # speed boots put on (want this here?)!
+        "You feel yourself slow down":False, # speed boots removed (want this here?)!
+        "You feel slow":False
     },
     "Teleportitis": {
        "You feel very jumpy":True,
@@ -70,9 +70,9 @@ messages = {
     },
     "Teleport control": {
         "You feel in control of yourself":True,
-        "You feel controlled!":True,
+        "You feel controlled":True,
         "You feel centered in your personal space":True,
-       "You feel less jumpy":False
+        "You feel less jumpy":False
     },
     "Telepathy": {
         "You feel in touch with the cosmos":True,

--- a/scripts/noobhack
+++ b/scripts/noobhack
@@ -10,6 +10,10 @@ import optparse
 
 import cPickle as pickle
 
+#import profile
+
+import cProfile
+
 import vt102 
 
 from noobhack import ui, telnet, process, proxy
@@ -314,9 +318,10 @@ class Noobhack:
 
 if __name__ == "__main__":
     locale.setlocale(locale.LC_ALL, "")
-
+    
     hack = Noobhack()
     try:
-        curses.wrapper(hack.run)
+#        profile.run('curses.wrapper(hack.run); print')     
+         cProfile.run('curses.wrapper(hack.run)', "noobhack.trace")
     except IOError, exit_message:
         print exit_message

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from distutils.core import setup, Extension
 
 setup(
     name="noobhack",
@@ -11,5 +11,6 @@ setup(
     requires=["vt102 (>=0.3.2)"],
     packages=["noobhack", "noobhack.game"],
     scripts=["scripts/noobhack"],
-    license="Lesser General Public License v3.0"
+    license="Lesser General Public License v3.0",
+    ext_modules=[Extension('intrinsicsC', ['intrinsics.cpp'])],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,8 @@
 from distutils.core import setup, Extension
 
+intrinsicsModule = Extension('intrinsicsC',
+		sources = ['noobhack/game/cpp/intrinsics.cpp'])
+
 setup(
     name="noobhack",
     version="0.3",
@@ -12,5 +15,5 @@ setup(
     packages=["noobhack", "noobhack.game"],
     scripts=["scripts/noobhack"],
     license="Lesser General Public License v3.0",
-    ext_modules=[Extension('intrinsicsC', ['intrinsics.cpp'])],
+    ext_modules=[intrinsicsModule], #Extension('intrinsicsC', ['noobhack/game/cpp/intrinsics.cpp'])],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 from distutils.core import setup, Extension
 
 intrinsicsModule = Extension('intrinsicsC',
-		sources = ['noobhack/game/cpp/intrinsics.cpp'])
+		sources = ['noobhack/game/cpp/intrinsics.cpp'],
+		libraries = ['boost_regex'])
 
 setup(
     name="noobhack",
@@ -17,3 +18,5 @@ setup(
     license="Lesser General Public License v3.0",
     ext_modules=[intrinsicsModule], #Extension('intrinsicsC', ['noobhack/game/cpp/intrinsics.cpp'])],
 )
+
+

--- a/test/game/test_intrinsics.py
+++ b/test/game/test_intrinsics.py
@@ -61,6 +61,15 @@ class IntrinsicsTest(unittest.TestCase):
 	  self.assertEqual(res.items()[1][0], "valA")
 	  self.assertEqual(res.items()[1][1], True)
 
+	def test_found_valA_Enabled_valB_Disabled(self):
+	  testInput = "aaa blah bbZ blah"
+	  uTestInput = testInput.decode('utf-8')
+	  res = intrinsicsC.DispatchIntrinsics(testIntrinsics, [uTestInput])
+	  self.assertEqual(len(res), 2)
+	  self.assertEqual(res.items()[0][0], "valB")
+	  self.assertEqual(res.items()[0][1], False)
+	  self.assertEqual(res.items()[1][0], "valA")
+	  self.assertEqual(res.items()[1][1], True)
 
 if __name__ == "__main__":
   unittest.main()

--- a/test/game/test_intrinsics.py
+++ b/test/game/test_intrinsics.py
@@ -10,24 +10,57 @@ testIntrinsics = {
     }
 
 class IntrinsicsTest(unittest.TestCase):
-#  def test_nullTestFail(self):
-#	self.assertEqual(1, 0)
-#
-#  def test_nullTestPass(self):
-#	self.assertEqual(1,1)
 
-	def test_parse(self):
+	def test_parseOnlyNoResult(self):
 	  testEmpty = ""
 	  uTestEmpty = testEmpty.decode('utf-8')
 	  res = intrinsicsC.DispatchIntrinsics(testIntrinsics, [uTestEmpty])
+	  self.assertEqual(len(res), 0)
 
-	def test_found_valA(self):
+	def test_found_valA_Enable(self):
 	  testInput = "blah aaa blah"
 	  uTestInput = testInput.decode('utf-8')
 	  res = intrinsicsC.DispatchIntrinsics(testIntrinsics, [uTestInput])
 	  self.assertEqual(len(res), 1)
 	  self.assertEqual(res.items()[0][0], "valA")
 	  self.assertEqual(res.items()[0][1], True)
+
+	def test_found_valA_Disable(self):
+	  testInput = "blah aaZ blah"
+	  uTestInput = testInput.decode('utf-8')
+	  res = intrinsicsC.DispatchIntrinsics(testIntrinsics, [uTestInput])
+	  self.assertEqual(len(res), 1)
+	  self.assertEqual(res.items()[0][0], "valA")
+	  self.assertEqual(res.items()[0][1], False)
+	
+	def test_found_valA_EnableDisable(self):
+	  testInput = "aaa blah aaZ blah"
+	  uTestInput = testInput.decode('utf-8')
+	  res = intrinsicsC.DispatchIntrinsics(testIntrinsics, [uTestInput])
+	  self.assertEqual(len(res), 1)
+	  self.assertEqual(res.items()[0][0], "valA")
+	  self.assertEqual(res.items()[0][1], False)
+
+	def test_found_valAvalB_Enabled(self):
+	  testInput = "aaa blah bbb blah"
+	  uTestInput = testInput.decode('utf-8')
+	  res = intrinsicsC.DispatchIntrinsics(testIntrinsics, [uTestInput])
+	  self.assertEqual(len(res), 2)
+	  self.assertEqual(res.items()[0][0], "valB")
+	  self.assertEqual(res.items()[0][1], True)
+	  self.assertEqual(res.items()[1][0], "valA")
+	  self.assertEqual(res.items()[1][1], True)
+
+	def test_found_valBvalA_Enabled(self):
+	  testInput = "bbb blah aaa blah"
+	  uTestInput = testInput.decode('utf-8')
+	  res = intrinsicsC.DispatchIntrinsics(testIntrinsics, [uTestInput])
+	  self.assertEqual(len(res), 2)
+	  self.assertEqual(res.items()[0][0], "valB")
+	  self.assertEqual(res.items()[0][1], True)
+	  self.assertEqual(res.items()[1][0], "valA")
+	  self.assertEqual(res.items()[1][1], True)
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/test/game/test_intrinsics.py
+++ b/test/game/test_intrinsics.py
@@ -1,0 +1,33 @@
+import unittest 
+
+import intrinsicsC
+
+testIntrinsics = {
+	"valA": { "aaa" : True,
+      "aaZ" : False },
+    "valB": { "bbb" :True,
+      "bbZ" : False },
+    }
+
+class IntrinsicsTest(unittest.TestCase):
+#  def test_nullTestFail(self):
+#	self.assertEqual(1, 0)
+#
+#  def test_nullTestPass(self):
+#	self.assertEqual(1,1)
+
+	def test_parse(self):
+	  testEmpty = ""
+	  uTestEmpty = testEmpty.decode('utf-8')
+	  res = intrinsicsC.DispatchIntrinsics(testIntrinsics, [uTestEmpty])
+
+	def test_found_valA(self):
+	  testInput = "blah aaa blah"
+	  uTestInput = testInput.decode('utf-8')
+	  res = intrinsicsC.DispatchIntrinsics(testIntrinsics, [uTestInput])
+	  self.assertEqual(len(res), 1)
+	  self.assertEqual(res.items()[0][0], "valA")
+	  self.assertEqual(res.items()[0][1], True)
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
Hi,

I found the searches done in Brain.py to look for intrinsic gained/lost messages were slowing down the game considerably in some circumstances (especially when entering long-ish lines in the console; e.g. specifying wishes, naming items or engraving messages).

The search code was basically looping through Dictionaries of Dictionaries in Python, then applying a regex search to the results.  To speed things up I've reimplemented the searching code in C++ with some pre-caching of the search terms and results, which seems to significantly improve performance.   

This could be extended to the other dispatch functions (e.g. _dispatch_status_events() -- if the Brain gets cleverer more functionality might need to be compiled into modules. 

Regular Expressions searching is handled using Boost::Regex -- I hope that dependency isn't a problem.  Boost is easily installable through aptitude or similar.

cheers,
Chris
