### PR TITLE
fix for terminal size on NAO

### DIFF
--- a/noobhack/telnet.py
+++ b/noobhack/telnet.py
@@ -56,7 +56,7 @@ class Telnet:
         elif command == telnetlib.DO and option == "\x1f":
             # And we should probably tell the server we will send our window
             # size
-            socket.sendall(pack(">cccHHcc", telnetlib.IAC, telnetlib.SB, telnetlib.NAWS, self.size[1]-1, self.size[0], telnetlib.IAC, telnetlib.SE))
+            socket.sendall(pack(">cccHHcc", telnetlib.IAC, telnetlib.SB, telnetlib.NAWS, self.size[1], self.size[0], telnetlib.IAC, telnetlib.SE))
         elif command == telnetlib.DO and option == "\x20":
             # Tell the server to sod off, we won't send the terminal speed
             socket.send("%s%s\x20" % (telnetlib.IAC, telnetlib.WONT))

--- a/noobhack/ui/game.py
+++ b/noobhack/ui/game.py
@@ -20,7 +20,12 @@ class Game:
         attributes appropriately.
         """
         row_c = self.term.display[row].encode(self.code)
-        window.addstr(row, 0, row_c)
+        max_y, max_x = window.getmaxyx()
+        if row == max_y -1:
+           window.addstr(row, 0, row_c[:-1])
+           window.insch(row_c[-1])
+        else:
+           window.addstr(row, 0, row_c)
 
         row_a = self.term.attributes[row]
         for col, (char_style, foreground, background) in enumerate(row_a): 

--- a/scripts/noobhack
+++ b/scripts/noobhack
@@ -142,7 +142,7 @@ class Noobhack:
         # deal with it rather than hunt forever trying to figure out what I'm
         # doing wrong with curses.
         rows, cols = size()
-        self.term = vt102.screen((rows-1, cols), self.options.encoding)
+        self.term = vt102.screen((rows, cols), self.options.encoding)
         self.term.attach(self.stream)
         self.output_proxy.register(self.stream.process)
 

--- a/scripts/noobhack
+++ b/scripts/noobhack
@@ -241,7 +241,8 @@ class Noobhack:
             else:
                 conn = telnet.Telnet(
                     self.options.host,
-                    self.options.port
+                    self.options.port,
+                    size()
                 )
             conn.open()
         except IOError, error:


### PR DESCRIPTION
With the off-by-one window size bug this might actually break something (such as _get_last_line), but clearly our local window size and the remote one should actually match instead of relying on it being wrong.
